### PR TITLE
.update action now will update both the instance and DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.2.3] - 2023-08-29
+- Fix PynamoTOMondoDBAdapter.count action. Now it can accept 
+  filter_condition and range_key_condition
+
 # [2.2.2] - 2023-08-23
 - Fix update action for PynamoTOMondoDBAdapter. Now if you use update, the 
   python instance will be updated as well.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [2.2.2] - 2023-08-23
+- Fix update action for PynamoTOMondoDBAdapter. Now if you use update, the 
+  python instance will be updated as well.
+
 # [2.2.1] - 2023-08-07
 - Fix a bug with PynamoTOMondoDBAdapter startswith condition
 - add `separators=(",", ":")` to json.dumps to make the payload a bit smaller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [2.2.2] - 2023-08-23
 - Fix update action for PynamoTOMondoDBAdapter. Now if you use update, the 
   python instance will be updated as well.
+- fix save method for batch_write for PynamoTOMondoDBAdapter
 
 # [2.2.1] - 2023-08-07
 - Fix a bug with PynamoTOMondoDBAdapter startswith condition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [2.2.3] - 2023-08-29
-- Fix PynamoTOMondoDBAdapter.count action. Now it can accept 
-  filter_condition and range_key_condition
-
-# [2.2.2] - 2023-08-23
+# [2.2.2] - 2023-08-29
 - Fix update action for PynamoTOMondoDBAdapter. Now if you use update, the 
   python instance will be updated as well.
 - fix save method for batch_write for PynamoTOMondoDBAdapter
+- Fix PynamoTOMondoDBAdapter.count action. Now it can accept
+  filter_condition and range_key_condition
 
 # [2.2.1] - 2023-08-07
 - Fix a bug with PynamoTOMondoDBAdapter startswith condition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix save method for batch_write for PynamoTOMondoDBAdapter
 - Fix PynamoTOMondoDBAdapter.count action. Now it can accept
   filter_condition and range_key_condition
+- Fix attributes_to_get (UnicodeAttribute is not hashable)
 
 # [2.2.1] - 2023-08-07
 - Fix a bug with PynamoTOMondoDBAdapter startswith condition

--- a/modular_sdk/models/pynamodb_extension/base_model.py
+++ b/modular_sdk/models/pynamodb_extension/base_model.py
@@ -445,6 +445,13 @@ class RawBaseModel(models.Model):
                   instance: Optional[_T] = None) -> models.Model:
         _id = model_json.pop('_id', None)
         instance = instance or cls()
+        if attributes_to_get:
+            to_get = set(
+                attr.attr_name if isinstance(attr, Attribute) else attr
+                for attr in attributes_to_get
+            )
+            model_json = {k: v for k, v in model_json.items() if k in to_get}
+
         attribute_values = {k: json_to_attribute_value(v) for k, v in
                             model_json.items()}
         # if uncommented, custom DynamicAttribute won't work due to
@@ -452,9 +459,6 @@ class RawBaseModel(models.Model):
         # instance._update_attribute_types(attribute_values)
         instance.deserialize(attribute_values)
         instance.mongo_id = _id
-        if attributes_to_get:
-            unwanted = set(instance.attribute_values) - set(attributes_to_get)
-            [instance.attribute_values.pop(a, None) for a in unwanted]
         return instance
 
     @staticmethod

--- a/modular_sdk/models/pynamodb_extension/base_model.py
+++ b/modular_sdk/models/pynamodb_extension/base_model.py
@@ -324,7 +324,14 @@ class RawBaseModel(models.Model):
             settings: OperationSettings = OperationSettings.default,
     ) -> int:
         if cls.is_docker:
-            return cls.mongodb_handler().count(model_class=cls)
+            return cls.mongodb_handler().count(
+                model_class=cls,
+                hash_key=hash_key,
+                range_key_condition=range_key_condition,
+                filter_condition=filter_condition,
+                index_name=index_name,
+                limit=limit
+            )
         return super().count(hash_key, range_key_condition, filter_condition,
                              consistent_read, index_name, limit, rate_limit,
                              settings)

--- a/modular_sdk/models/pynamodb_extension/base_model.py
+++ b/modular_sdk/models/pynamodb_extension/base_model.py
@@ -434,9 +434,10 @@ class RawBaseModel(models.Model):
 
     @classmethod
     def from_json(cls, model_json: dict,
-                  attributes_to_get: Optional[List] = None) -> models.Model:
+                  attributes_to_get: Optional[List] = None,
+                  instance: Optional[_T] = None) -> models.Model:
         _id = model_json.pop('_id', None)
-        instance = cls()
+        instance = instance or cls()
         attribute_values = {k: json_to_attribute_value(v) for k, v in
                             model_json.items()}
         # if uncommented, custom DynamicAttribute won't work due to

--- a/modular_sdk/models/pynamodb_extension/base_safe_update_model.py
+++ b/modular_sdk/models/pynamodb_extension/base_safe_update_model.py
@@ -163,13 +163,14 @@ class BaseSafeUpdateModel(BaseModel):
 
     @classmethod
     def from_json(cls, model_json: dict,
-                  attributes_to_get: Optional[List] = None
+                  attributes_to_get: Optional[List] = None, instance=None
                   ) -> Optional[models.Model]:
         """
         For MongoDB
         TODO use attributes_to_get as projection expression
         :param model_json:
         :param attributes_to_get:
+        :param instance:
         :return:
         """
         if not model_json:
@@ -177,6 +178,6 @@ class BaseSafeUpdateModel(BaseModel):
         _additional_data = \
             cls._retrieve_additional_data(model_json, cls.get_attributes())
         _additional_data.pop('_id', None)
-        instance = super().from_json(model_json, attributes_to_get)
+        instance = super().from_json(model_json, attributes_to_get, instance)
         setattr(instance, cls._additional_data_attr_name, _additional_data)
         return instance

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = modular_sdk
-version = 2.2.3
+version = 2.2.2
 requires-python = >=3.8
 classifiers =
     Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = modular_sdk
-version = 2.2.1
+version = 2.2.2
 requires-python = >=3.8
 classifiers =
     Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = modular_sdk
-version = 2.2.2
+version = 2.2.3
 requires-python = >=3.8
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
PynamoDBToPyMongoAdapter.update action updated only DB document but not the item itself. This is not the way PynamoDB behaves. This MR fixes it