### PR TITLE
Add consistent_read to the get_nullable(); Add ability to set `component` not only via env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.3.10] - 2023-12-14
+- add optional `consistent_read` argument to the `get_nullable` function
+- add the ability to set `component` of `job_tracer` decorator also manually via an argument
+
 # [3.3.9] - 2023-12-08
 - add methods for force deletion of Application/Parent
 

--- a/modular_sdk/commons/trace_helper.py
+++ b/modular_sdk/commons/trace_helper.py
@@ -12,13 +12,14 @@ def __resolve_event(args, kwargs):
         return kwargs['event']
     return args[0]
 
+
 def __resolve_context(args, kwargs):
     if len(args) != 2:
         return kwargs['context']
     return args[1]
 
 
-def tracer_decorator(is_scheduled=False, is_job=False):
+def tracer_decorator(is_scheduled=False, is_job=False, component=None):
     def real_wrapper(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -34,7 +35,8 @@ def tracer_decorator(is_scheduled=False, is_job=False):
                 operation_mode_service = ModularOperationModeManagerService()
                 job_tracer = ModularJobTracer(
                     operation_mode_service=operation_mode_service,
-                    environment_service=environment_service
+                    environment_service=environment_service,
+                    component=component
                 )
 
                 event = __resolve_event(args, kwargs)

--- a/modular_sdk/models/pynamodb_extension/base_model.py
+++ b/modular_sdk/models/pynamodb_extension/base_model.py
@@ -227,13 +227,15 @@ class RawBaseModel(models.Model):
         return os.environ.get(MODULAR_SERVICE_MODE_ENV) == SERVICE_MODE_DOCKER
 
     @classmethod
-    def get_nullable(cls, hash_key, range_key=None, attributes_to_get=None):
+    def get_nullable(cls, hash_key, range_key=None, attributes_to_get=None,
+                     consistent_read=False):
         if cls.is_docker:
             return cls.mongodb_handler().get_nullable(
                 model_class=cls, hash_key=hash_key, sort_key=range_key)
         try:
             return cls.get(hash_key, range_key,
-                           attributes_to_get=attributes_to_get)
+                           attributes_to_get=attributes_to_get,
+                           consistent_read=consistent_read)
         except DoesNotExist as e:
             _LOG.debug(f'{cls.__name__} does not exist '
                        f'with the following keys: hash_key={hash_key}, '

--- a/modular_sdk/utils/job_tracer/generic.py
+++ b/modular_sdk/utils/job_tracer/generic.py
@@ -17,11 +17,11 @@ _LOG = get_logger('modular_sdk-job-tracer')
 
 class ModularJobTracer(AbstractJobTracer):
     def __init__(self, operation_mode_service: ModularOperationModeManagerService,
-                 environment_service: EnvironmentService):
+                 environment_service: EnvironmentService, component=None):
         self.operation_mode_service = operation_mode_service
         self.environment_service = environment_service
         self.application = self.environment_service.application()
-        self.component = self.environment_service.component()
+        self.component = component or self.environment_service.component()
 
     def start(self, job_id):
         _LOG.debug(f'Going to mark Job {self.component} and {job_id} id as '
@@ -29,9 +29,9 @@ class ModularJobTracer(AbstractJobTracer):
 
         # self.is_permitted_to_start()
         job = JobService.create(job=self.component, job_id=job_id,
-                                    application=self.application, 
-                                    started_at=datetime.utcnow(), 
-                                    state=JOB_RUNNING_STATE, meta={})
+                                application=self.application,
+                                started_at=datetime.utcnow(),
+                                state=JOB_RUNNING_STATE, meta={})
         JobService.save(job=job)
 
     def is_permitted_to_start(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = modular_sdk
-version = 3.3.9
+version = 3.3.10
 python_requires = >=3.8
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
Add optional `consistent_read` argument to the `get_nullable` function;
Add the ability to set `component` of `job_tracer` decorator also manually via an argument;
