### PR TITLE
4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [4.0.3] - 2024-01-24
+- Parent service: switch to using application_id index instead of scans
+
 # [4.0.2] - 2024-01-18
 - Fix `ct` (creation_timestamp) to store as an int in `Parent` table
 

--- a/modular_sdk/models/parent.py
+++ b/modular_sdk/models/parent.py
@@ -75,7 +75,7 @@ class Parent(BaseRoleAccessModel):
     created_by = UnicodeAttribute(attr_name=CREATED_BY, null=True)
 
     customer_id_scope_index = CustomerIdScopeIndex()
-    # application_id_index = ApplicationIdIndex()  # use when it becomes real
+    application_id_index = ApplicationIdIndex()
 
     # todo use if self.type is removed
     # @property

--- a/modular_sdk/services/parent_service.py
+++ b/modular_sdk/services/parent_service.py
@@ -47,12 +47,16 @@ class ParentService:
                                    limit: Optional[int] = None,
                                    last_evaluated_key: Optional[dict] = None
                                    ) -> Iterator[Parent]:
-        # TODO refactor to use index
-        condition = Parent.application_id == application_id
+        condition = None
         if only_active:
-            condition &= (Parent.is_deleted == False)
-        return Parent.scan(filter_condition=condition, limit=limit,
-                           last_evaluated_key=last_evaluated_key)
+            condition = (Parent.is_deleted == False)
+
+        return Parent.application_id_index.query(
+            hash_key=application_id,
+            filter_condition=condition,
+            limit=limit,
+            last_evaluated_key=last_evaluated_key
+        )
 
     def i_get_parent_by_customer(self, customer_id: str,
                                  parent_type: Optional[Union[ParentType, List[ParentType]]] = None,  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = modular_sdk
-version = 4.0.2
+version = 4.0.3
 python_requires = >=3.8
 classifiers =
     Programming Language :: Python :: 3


### PR DESCRIPTION
# [4.0.3] - 2024-01-24
- Parent service: switch to using application_id index instead of scans