### PR TITLE
Fix 'get_signed_headers' to support 'http' or 'rabbit' headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.1] - 2024-11-25
+- Update `get_signed_headers` to support conditional handling of `http` and
+`rabbit` specific headers
+
 ## [6.3.0] - 2024-11-20
 - Fix Vault parameters encoder to comply with Maestro format
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [6.3.1] - 2024-11-25
+## [6.3.0] - 2024-11-26
+- Fix Vault parameters encoder to comply with Maestro format
 - Update `get_signed_headers` to support conditional handling of `http` and
 `rabbit` specific headers
-
-## [6.3.0] - 2024-11-20
-- Fix Vault parameters encoder to comply with Maestro format
 
 ## [6.2.1] - 2024-10-18
 - Update `Modular` and `MaestroHTTPTransport` classes

--- a/modular_sdk/services/impl/maestro_http_transport_service.py
+++ b/modular_sdk/services/impl/maestro_http_transport_service.py
@@ -83,7 +83,9 @@ class MaestroHTTPTransport(AbstractTransport):
         _LOG.debug('Message encrypted')
         # sign headers
         headers = signer.get_signed_headers(
-            async_request=async_request, compressed=compressed,
+            async_request=async_request,
+            compressed=compressed,
+            http=True,
         )
         _LOG.debug('Signed headers prepared')
         return encrypted_body, headers

--- a/modular_sdk/services/impl/maestro_http_transport_service.py
+++ b/modular_sdk/services/impl/maestro_http_transport_service.py
@@ -82,10 +82,8 @@ class MaestroHTTPTransport(AbstractTransport):
 
         _LOG.debug('Message encrypted')
         # sign headers
-        headers = signer.get_signed_headers(
-            async_request=async_request,
-            compressed=compressed,
-            http=True,
+        headers = signer.get_http_signed_headers(
+            async_request=async_request, compressed=compressed,
         )
         _LOG.debug('Signed headers prepared')
         return encrypted_body, headers

--- a/modular_sdk/services/impl/maestro_signature_builder.py
+++ b/modular_sdk/services/impl/maestro_signature_builder.py
@@ -58,8 +58,12 @@ class MaestroSignatureBuilder:
         encrypted_data_with_iv = bytes(iv) + encrypted_data
         return base64.b64encode(encrypted_data_with_iv)
 
-    def get_signed_headers(self, async_request: bool = False,
-                           compressed: bool = False) -> dict:
+    def get_signed_headers(
+            self,
+            async_request: bool = False,
+            compressed: bool = False,
+            http: bool = False,
+    ) -> dict:
         """
         Create and sign necessary headers for interaction with Maestro API
         """
@@ -76,7 +80,8 @@ class MaestroSignatureBuilder:
         resolved_signature = ''
         for each in [signature[i:i + n] for i in range(0, len(signature), n)]:
             resolved_signature += '1' + each
-        return {
+
+        headers = {
             "maestro-authentication": resolved_signature,
             "maestro-request-identifier": "api-server",
             "maestro-user-identifier": self._user,
@@ -86,3 +91,8 @@ class MaestroSignatureBuilder:
             "maestro-sdk-async": 'true' if async_request else 'false',
             "compressed": True if compressed else False,
         }
+        if http:
+            headers["compressed"] = 'true' if compressed else 'false'
+            headers["Content-Type"] = PLAIN_CONTENT_TYPE
+
+        return headers

--- a/modular_sdk/services/impl/maestro_signature_builder.py
+++ b/modular_sdk/services/impl/maestro_signature_builder.py
@@ -87,8 +87,10 @@ class MaestroSignatureBuilder:
             "compressed": True if compressed else False,
         }
 
-    def get_http_signed_headers(self, async_request: bool = False, compressed: bool = False):
-        base = self.get_signed_headers(async_request=async_request, compressed=compressed)
+    def get_http_signed_headers(self, async_request: bool = False, 
+                                compressed: bool = False) -> dict:
+        base = self.get_signed_headers(async_request=async_request, 
+                                       compressed=compressed)
         base['compressed'] = 'true' if base['compressed'] else 'false'
         base['Content-Type'] = PLAIN_CONTENT_TYPE
         return base

--- a/modular_sdk/services/impl/maestro_signature_builder.py
+++ b/modular_sdk/services/impl/maestro_signature_builder.py
@@ -76,7 +76,6 @@ class MaestroSignatureBuilder:
         resolved_signature = ''
         for each in [signature[i:i + n] for i in range(0, len(signature), n)]:
             resolved_signature += '1' + each
-
         return {
             "maestro-authentication": resolved_signature,
             "maestro-request-identifier": "api-server",

--- a/modular_sdk/services/impl/maestro_signature_builder.py
+++ b/modular_sdk/services/impl/maestro_signature_builder.py
@@ -58,12 +58,8 @@ class MaestroSignatureBuilder:
         encrypted_data_with_iv = bytes(iv) + encrypted_data
         return base64.b64encode(encrypted_data_with_iv)
 
-    def get_signed_headers(
-            self,
-            async_request: bool = False,
-            compressed: bool = False,
-            http: bool = False,
-    ) -> dict:
+    def get_signed_headers(self, async_request: bool = False,
+                           compressed: bool = False) -> dict:
         """
         Create and sign necessary headers for interaction with Maestro API
         """
@@ -81,7 +77,7 @@ class MaestroSignatureBuilder:
         for each in [signature[i:i + n] for i in range(0, len(signature), n)]:
             resolved_signature += '1' + each
 
-        headers = {
+        return {
             "maestro-authentication": resolved_signature,
             "maestro-request-identifier": "api-server",
             "maestro-user-identifier": self._user,
@@ -91,8 +87,10 @@ class MaestroSignatureBuilder:
             "maestro-sdk-async": 'true' if async_request else 'false',
             "compressed": True if compressed else False,
         }
-        if http:
-            headers["compressed"] = 'true' if compressed else 'false'
-            headers["Content-Type"] = PLAIN_CONTENT_TYPE
 
-        return headers
+    def get_http_signed_headers(self, async_request: bool = False, compressed: bool = False):
+        base = self.get_signed_headers(async_request=async_request, compressed=compressed)
+        base['compressed'] = 'true' if base['compressed'] else 'false'
+        base['Content-Type'] = PLAIN_CONTENT_TYPE
+        return base
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modular_sdk"
-version = "6.3.0"
+version = "6.3.1"
 authors = [
     {name = "EPAM Systems", email = "support@syndicate.team"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modular_sdk"
-version = "6.3.1"
+version = "6.3.0"
 authors = [
     {name = "EPAM Systems", email = "support@syndicate.team"}
 ]

--- a/tests/test_maestro_signature_builder.py
+++ b/tests/test_maestro_signature_builder.py
@@ -69,3 +69,24 @@ def test_get_headers():
             'maestro-accesskey': 'access_key', 'maestro-sdk-version': '3.2.80',
             'maestro-sdk-async': 'true', 'compressed': True
         }
+
+def test_get_http_headers():
+    signer = MaestroSignatureBuilder(
+        access_key='access_key',
+        secret_key='1234567890123456',
+        user='user'
+    )
+    with patch('time.time', lambda: 1728655109.171027):
+        headers = signer.get_http_signed_headers(
+            async_request=True,
+            compressed=True
+        )
+        assert headers == {
+            'maestro-authentication': '19a1e711211517d16a1d015910a1141191a111111f12b16714714a1b41941111001c319b13e10114b1d412417b1f21e9',
+            'maestro-request-identifier': 'api-server',
+            'maestro-user-identifier': 'user', 'maestro-date': '1728655109171',
+            'maestro-accesskey': 'access_key', 'maestro-sdk-version': '3.2.80',
+            'maestro-sdk-async': 'true', 'compressed': 'true', 
+            'Content-Type': 'text/plain'
+
+        }

--- a/tests/test_maestro_signature_builder.py
+++ b/tests/test_maestro_signature_builder.py
@@ -88,5 +88,4 @@ def test_get_http_headers():
             'maestro-accesskey': 'access_key', 'maestro-sdk-version': '3.2.80',
             'maestro-sdk-async': 'true', 'compressed': 'true', 
             'Content-Type': 'text/plain'
-
         }


### PR DESCRIPTION
Update 'get_signed_headers' to support conditional handling of `http` and `rabbit`